### PR TITLE
Several Bugfixes for PHP Warnings

### DIFF
--- a/Classes/Controller/Be/TranslatorController.php
+++ b/Classes/Controller/Be/TranslatorController.php
@@ -419,9 +419,9 @@ class TranslatorController extends \TYPO3\CMS\Extbase\Mvc\Controller\ActionContr
         foreach ($storages as $storage) {
             foreach($tables as $tablename) {
 
-                foreach ($databaseEntriesService->getAllComplteteRowsForPid($tablename, (int) $storage, $sourceLangauge,false) as $contentRow) {
+                foreach ($databaseEntriesService->getAllCompleteteRowsForPid($tablename, (int) $storage, $sourceLangauge,false) as $contentRowUid => $contentRow) {
                     $cleanRow = $databaseEntriesService->getExportFields($tablename, $contentRow);
-                    $output = $databaseEntriesService->exportDatabaseRowToXlf($contentRow['uid'], $cleanRow, $targetLanguage, $tablename, $enableTranslatedData, $source);
+                    $output = $databaseEntriesService->exportDatabaseRowToXlf($contentRowUid, $cleanRow, $targetLanguage, $tablename, $enableTranslatedData, $source);
 
                     if ($saveToZip) {
                         if (version_compare(PHP_VERSION, '8.0.0') >= 0) {

--- a/Classes/Controller/Be/TranslatorController.php
+++ b/Classes/Controller/Be/TranslatorController.php
@@ -415,13 +415,16 @@ class TranslatorController extends \TYPO3\CMS\Extbase\Mvc\Controller\ActionContr
         }
 
         $xlfService = GeneralUtility::makeInstance(\Hyperdigital\HdTranslator\Services\XlfService::class);
-
+        $output = '';
         foreach ($storages as $storage) {
             foreach($tables as $tablename) {
-
-                foreach ($databaseEntriesService->getAllCompleteteRowsForPid($tablename, (int) $storage, $sourceLangauge,false) as $contentRowUid => $contentRow) {
+                $contentRows = $databaseEntriesService->getAllCompleteteRowsForPid($tablename, (int) $storage, $sourceLangauge,false);
+                if(empty($contentRows)) {
+                    $output .= ' No entries in '.$tablename.' for pid '.$storage;
+                }
+                foreach ($contentRows as $contentRowUid => $contentRow) {
                     $cleanRow = $databaseEntriesService->getExportFields($tablename, $contentRow);
-                    $output = $databaseEntriesService->exportDatabaseRowToXlf($contentRowUid, $cleanRow, $targetLanguage, $tablename, $enableTranslatedData, $source);
+                    $output .= $databaseEntriesService->exportDatabaseRowToXlf($contentRowUid, $cleanRow, $targetLanguage, $tablename, $enableTranslatedData, $source);
 
                     if ($saveToZip) {
                         if (version_compare(PHP_VERSION, '8.0.0') >= 0) {
@@ -437,16 +440,23 @@ class TranslatorController extends \TYPO3\CMS\Extbase\Mvc\Controller\ActionContr
         if ($saveToZip) {
             $zip->close();
 
-            header('Pragma: public');
-            header('Expires: 0');
-            header('Cache-Control: must-revalidate, post-check=0, pre-check=0');
-            header('Cache-Control: private', false);
-            header('Content-Type: application/zip');
-            header('Content-Disposition: attachment; filename="' . basename($zipPath) . '";');
-            header('Content-Transfer-Encoding: binary');
-            header('Content-Length: ' . filesize($zipPath));
-            echo file_get_contents($zipPath);
-            \Hyperdigital\HdTranslator\Services\FileService::rmdir($zipFolder);
+            //if no records are found, the zip file would be empty, which is not valid
+            //zip file is automatically deleted by ZipArchive, fallback to printing the output
+            if(file_exists($zipPath)) {
+                header('Pragma: public');
+                header('Expires: 0');
+                header('Cache-Control: must-revalidate, post-check=0, pre-check=0');
+                header('Cache-Control: private', false);
+                header('Content-Type: application/zip');
+                header('Content-Disposition: attachment; filename="' . basename($zipPath) . '";');
+                header('Content-Transfer-Encoding: binary');
+                header('Content-Length: ' . filesize($zipPath));
+                echo file_get_contents($zipPath);
+                \Hyperdigital\HdTranslator\Services\FileService::rmdir($zipFolder);
+            }else {
+                echo $output;
+            }
+
         } else {
             header('Pragma: public');
             header('Expires: 0');

--- a/Classes/Controller/Be/TranslatorController.php
+++ b/Classes/Controller/Be/TranslatorController.php
@@ -392,6 +392,8 @@ class TranslatorController extends \TYPO3\CMS\Extbase\Mvc\Controller\ActionContr
         $defaultLanguage = 1;
         $sourceLangauge = 0;
         $targetLanguage = 'de';
+        //set to true, because it's the default value in $databaseEntriesService->exportDatabaseRowToXlf()
+        $enableTranslatedData = true;
         if ($this->request->hasArgument('language')) {
             $targetLanguage = $this->request->getArgument('language');
         }

--- a/Classes/Controller/Be/TranslatorController.php
+++ b/Classes/Controller/Be/TranslatorController.php
@@ -319,8 +319,8 @@ class TranslatorController extends \TYPO3\CMS\Extbase\Mvc\Controller\ActionContr
         } else {
             $this->indexMenu();
 
+            $data = [];
             if (!empty($GLOBALS['TYPO3_CONF_VARS']['translator'])) {
-                $data = [];
                 foreach ($GLOBALS['TYPO3_CONF_VARS']['translator'] as $key => $value) {
                     $category = '-';
                     if (!empty($value['category'])) {

--- a/Classes/Hooks/DocHeaderButtonsHook.php
+++ b/Classes/Hooks/DocHeaderButtonsHook.php
@@ -26,7 +26,7 @@ class DocHeaderButtonsHook
     {
         $request = $this->getRequest();
         if ($request && $GLOBALS['BE_USER']->check('modules', 'hd_translator_engine')) {
-            $currentUid = (int) $request->getQueryParams()['id'];
+            $currentUid = (int)($request->getQueryParams()['id'] ?? 0);
             $module = $request->getAttribute('module');
             $route = $request->getAttribute('route');
 

--- a/Classes/Services/DatabaseEntriesService.php
+++ b/Classes/Services/DatabaseEntriesService.php
@@ -59,7 +59,7 @@ class DatabaseEntriesService
             }
         }
 
-        $typeArrayReturn = $typeArray;
+        $typeArrayReturn = $typeArray ?? [];
 
         if (isset($typeArray['translator_export'])) {
             $listOfFields = GeneralUtility::trimExplode(',',$typeArray['translator_export']);

--- a/Classes/Services/DatabaseEntriesService.php
+++ b/Classes/Services/DatabaseEntriesService.php
@@ -298,7 +298,7 @@ class DatabaseEntriesService
      * @param int $pid - PID where the rows are stored (if lower then 0 then it's over the whole database)
      * @param bool $clean - return cleaned rows
      */
-    public function getAllComplteteRowsForPid(string $tablename, int $pid, int $sourceLanguage = 0, bool $clean = false)
+    public function getAllCompleteteRowsForPid(string $tablename, int $pid, int $sourceLanguage = 0, bool $clean = false)
     {
         $return = [];
         $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)->getConnectionForTable($tablename)->createQueryBuilder();
@@ -349,9 +349,9 @@ class DatabaseEntriesService
 
         while($row = $result->fetchAssociative()) {
             if ($clean) {
-                $return[] = $this->getExportFields($tablename, $row);
+                $return[$row['uid']] = $this->getExportFields($tablename, $row);
             } else {
-                $return[] = $row;
+                $return[$row['uid']] = $row;
             }
         }
 
@@ -859,15 +859,15 @@ class DatabaseEntriesService
 
         $realUid = $uid;// PID of other contents
         if ($row['sys_language_uid'] != 0 ) {
-            $realUid = $row['l10n_parent']; // The page is just translation;
+            $realUid = (int)$row['l10n_parent']; // The page is just translation;
         }
         if ($clean) {
             $row = $this->getExportFields('pages', $row);
-            $output = $this->prepareDataFromRow((int) $row['uid'], $row, $targetLanguage, 'pages');
+            $output = $this->prepareDataFromRow($realUid, $row, $targetLanguage, 'pages');
         }
 
-        foreach ($this->getAllComplteteRowsForPid('tt_content', $realUid, $sourceLanguage, $clean) as $contentRow) {
-            $output = array_merge($output, $this->prepareDataFromRow((int) $contentRow['uid'], $contentRow, $targetLanguage, 'tt_content'));
+        foreach ($this->getAllCompleteteRowsForPid('tt_content', $realUid, $sourceLanguage, $clean) as $contentRowUid => $contentRow) {
+            $output = array_merge($output, $this->prepareDataFromRow($contentRowUid, $contentRow, $targetLanguage, 'tt_content'));
         }
 
         return $output;

--- a/Classes/Services/DatabaseEntriesService.php
+++ b/Classes/Services/DatabaseEntriesService.php
@@ -41,7 +41,7 @@ class DatabaseEntriesService
 
     public function getListOfTranslatableFields($tablename, $row, &$typeArrayReturn = [])
     {
-        if (!empty($row[$GLOBALS['TCA'][$tablename]['ctrl']['type']])) {
+        if (isset($GLOBALS['TCA'][$tablename]['ctrl']['type']) && !empty($row[$GLOBALS['TCA'][$tablename]['ctrl']['type']])) {
             self::$rowTypeCouldBe = $row[$GLOBALS['TCA'][$tablename]['ctrl']['type']];
         }
         if (

--- a/Classes/Services/DatabaseEntriesService.php
+++ b/Classes/Services/DatabaseEntriesService.php
@@ -27,7 +27,7 @@ class DatabaseEntriesService
     public static $onlyDebug = false;
 
 
-    public static $importStats = ['updates' => 0, 'inserts' => 0, 'fails' => 0, 'failsMessagesfailsMessages' => []];
+    public static $importStats = ['updates' => 0, 'inserts' => 0, 'fails' => 0, 'failsMessages' => []];
     protected $updateAfterImport = [];
 
     protected $flexFormService;

--- a/Configuration/Backend/Modules.php
+++ b/Configuration/Backend/Modules.php
@@ -4,7 +4,7 @@ return [
     'hd_translator_engine' => [
         'parent' => 'web',
         'position' => ['after' => 'web_info'],
-        'access' => 'group',
+        'access' => 'user',
         'iconIdentifier' => 'hd_translator_icon',
         'navigationComponentId' => '',
         'inheritNavigationComponentFromMainModule' => false,

--- a/Configuration/Icons.php
+++ b/Configuration/Icons.php
@@ -1,0 +1,11 @@
+<?php
+return [
+    'hd_translator_icon' => [
+        'provider' => \TYPO3\CMS\Core\Imaging\IconProvider\SvgIconProvider::class,
+        'source' => 'EXT:hd_translator/Resources/Public/Icons/typo3_icon_lang-switch.svg',
+    ],
+    'hd_translator_icon_doc_header' => [
+        'provider' => \TYPO3\CMS\Core\Imaging\IconProvider\SvgIconProvider::class,
+        'source' => 'EXT:hd_translator/Resources/Public/Icons/typo3_icon_lang-switch_docheader.svg',
+    ],
+];

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -8,4 +8,6 @@ defined('TYPO3') or die();
 (function () {
     $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['Backend\Template\Components\ButtonBar']['getButtonsHook'][] =
         \Hyperdigital\HdTranslator\Hooks\DocHeaderButtonsHook::class . '->addExportButton';
+
+    $GLOBALS['TYPO3_CONF_VARS']['BE']['stylesheets']['hd_translator'] = 'EXT:hd_translator/Resources/Public/Css/Backend/';
 })();

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -6,21 +6,6 @@
 defined('TYPO3') or die();
 
 (function () {
-    $iconRegistry = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(
-        \TYPO3\CMS\Core\Imaging\IconRegistry::class
-    );
-
-    $iconRegistry->registerIcon(
-        'hd_translator_icon',
-        \TYPO3\CMS\Core\Imaging\IconProvider\SvgIconProvider::class,
-        ['source' => 'EXT:hd_translator/Resources/Public/Icons/typo3_icon_lang-switch.svg']
-    );
-    $iconRegistry->registerIcon(
-        'hd_translator_icon_doc_header',
-        \TYPO3\CMS\Core\Imaging\IconProvider\SvgIconProvider::class,
-        ['source' => 'EXT:hd_translator/Resources/Public/Icons/typo3_icon_lang-switch_docheader.svg']
-    );
-
     $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['Backend\Template\Components\ButtonBar']['getButtonsHook'][] =
         \Hyperdigital\HdTranslator\Hooks\DocHeaderButtonsHook::class . '->addExportButton';
 })();

--- a/ext_tables.php
+++ b/ext_tables.php
@@ -1,10 +1,6 @@
 <?php
 defined('TYPO3') or die();
 (function () {
-
-
-    $GLOBALS['TBE_STYLES']['skins']['hd_translator']['stylesheetDirectories'][] = 'EXT:hd_translator/Resources/Public/Css/Backend/';
-
     \Hyperdigital\HdTranslator\Helpers\TranslationHelper::setupTranslation();
 
     // TODO: hook list rightbar menu to add direct download -> EXT:sysext/recordlist/Classes/Controller/RecordListController.php:417


### PR DESCRIPTION
- Fixed several PHP warnings (PHP 8.3)
- Avoid a file not found exception: If no records can be found for a table on the given pid the zip file would be empty, ZipArchive automatically deletes those. 