### PR TITLE
databaseExport reset $output var 

### DIFF
--- a/Classes/Controller/Be/TranslatorController.php
+++ b/Classes/Controller/Be/TranslatorController.php
@@ -420,11 +420,11 @@ class TranslatorController extends \TYPO3\CMS\Extbase\Mvc\Controller\ActionContr
             foreach($tables as $tablename) {
                 $contentRows = $databaseEntriesService->getAllCompleteteRowsForPid($tablename, (int) $storage, $sourceLangauge,false);
                 if(empty($contentRows)) {
-                    $output .= ' No entries in '.$tablename.' for pid '.$storage;
+                    $output = ' No entries in '.$tablename.' for pid '.$storage;
                 }
                 foreach ($contentRows as $contentRowUid => $contentRow) {
                     $cleanRow = $databaseEntriesService->getExportFields($tablename, $contentRow);
-                    $output .= $databaseEntriesService->exportDatabaseRowToXlf($contentRowUid, $cleanRow, $targetLanguage, $tablename, $enableTranslatedData, $source);
+                    $output = $databaseEntriesService->exportDatabaseRowToXlf($contentRowUid, $cleanRow, $targetLanguage, $tablename, $enableTranslatedData, $source);
 
                     if ($saveToZip) {
                         if (version_compare(PHP_VERSION, '8.0.0') >= 0) {


### PR DESCRIPTION
so that the run of the foreach has not the values from the previous run in it


I have the Issue that from the second file on i have always the content from the file before in it when i export database entrys
![image](https://github.com/user-attachments/assets/ff0c56c4-4494-4995-a1c0-98eb09d4eb7d)
