### PR TITLE
[BUGFIX] Declare missing property in TranslatorController

### DIFF
--- a/Classes/Controller/Be/TranslatorController.php
+++ b/Classes/Controller/Be/TranslatorController.php
@@ -65,6 +65,7 @@ class TranslatorController extends \TYPO3\CMS\Extbase\Mvc\Controller\ActionContr
 
     protected $pageUid = 0;
     protected $pageData = [];
+    protected $moduleTemplate;
 
     public function __construct(
         protected readonly ListUtility $listUtility,


### PR DESCRIPTION
The `$moduleTemplate` property was obviously removed with 88e4d71d02c49890b0640bce61930cd07722706a. This PR re-adds the property to avoid deprecation notices due to the use of dynamically assigned properties.

Resolves: #25