### PR TITLE
Make extension workable alongside powermail, improve empty trans-unit handling, preserver correct colPos

### DIFF
--- a/Classes/Services/XlfService.php
+++ b/Classes/Services/XlfService.php
@@ -177,6 +177,18 @@ class XlfService
                         $insert = (isset($item[$sourcePath]) && !is_array($item[$sourcePath])) ? $item[$sourcePath] : '';
                     }
 
+                    // Skip empty trans-unit items: if both source and target are empty (or target is empty when source is disabled)
+                    // This prevents creating entries for completely empty translation nodes
+                    $isEmpty = false;
+                    if ($enableSource) {
+                        $isEmpty = (trim((string)($insert[$source] ?? '')) === '' && trim((string)($insert[$target] ?? '')) === '');
+                    } else {
+                        $isEmpty = (trim((string)$insert) === '');
+                    }
+                    if ($isEmpty) {
+                        continue;
+                    }
+
                     $return[$item['@attributes']['id']] = $insert;
                 }
             } else {
@@ -187,6 +199,16 @@ class XlfService
                     ];
                 } else {
                     $insert = (isset($data['file']['body']['trans-unit'][$sourcePath])) ? $data['file']['body']['trans-unit'][$sourcePath] : '';
+                }
+                // Skip empty single trans-unit: same rule as above
+                $isEmpty = false;
+                if ($enableSource) {
+                    $isEmpty = (trim((string)($insert[$source] ?? '')) === '' && trim((string)($insert[$target] ?? '')) === '');
+                } else {
+                    $isEmpty = (trim((string)$insert) === '');
+                }
+                if ($isEmpty) {
+                    return $return;
                 }
 
                 $return[$data['file']['body']['trans-unit']['@attributes']['id']] = $insert;

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
   "license": "GPL-2.0-or-later",
   "require": {
     "typo3/cms-core": ">=13.0 <13.99",
-    "phpoffice/phpspreadsheet": "4.*",
+    "phpoffice/phpspreadsheet": "4.*"
   },
   "extra": {
     "typo3/cms": {

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
   "license": "GPL-2.0-or-later",
   "require": {
     "typo3/cms-core": ">=13.0 <13.99",
-    "phpoffice/phpspreadsheet": "1.*"
+    "phpoffice/phpspreadsheet": "4.*",
   },
   "extra": {
     "typo3/cms": {


### PR DESCRIPTION
Hi,

I found several problems using the "Database import" function, when importing a translated page:

- empty trans-unit nodes produced database query errors with integer fields, so I implemented a skip mechanism
- if the the 'colPos' value of the l18n_parent record was not 0, the translated content record was not in sync - not it gets preserved

Initially I had to raise the 'phpoffice/phpspreadsheet' dependency, to make the extension work alongside the widely user powermail extension. (not tested extensively).

Best regards,
Uwe