### PR TITLE
[FEATURE] Make it possible to select the source language

### DIFF
--- a/Classes/Controller/Be/TranslatorController.php
+++ b/Classes/Controller/Be/TranslatorController.php
@@ -15,6 +15,8 @@ use TYPO3\CMS\Core\Context\LanguageAspect;
 use TYPO3\CMS\Core\Core\Environment;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Database\Query\Restriction\DeletedRestriction;
+use TYPO3\CMS\Core\Site\SiteFinder;
+use TYPO3\CMS\Core\Site\Exception\SiteNotFoundException;
 use TYPO3\CMS\Core\Imaging\Icon;
 use TYPO3\CMS\Core\Imaging\IconFactory;
 use TYPO3\CMS\Core\Localization\LanguageService;
@@ -103,6 +105,55 @@ class TranslatorController extends \TYPO3\CMS\Extbase\Mvc\Controller\ActionContr
             $this->pageUid = (int)$currentPid;
             $this->pageData = $this->pageRepository->getPage($this->pageUid, true);
         }
+    }
+
+    /**
+     * Returns available languages from the site configuration (TYPO3 v13) for source language dropdowns.
+     * Uses the current page's site or falls back to all sites to collect languages.
+     *
+     * @return array<int, array{uid: int, title: string}>
+     */
+    protected function getAllowedSystemLanguages(): array
+    {
+        $allowedLanguages = [];
+        $seenIds = [];
+        $siteFinder = GeneralUtility::makeInstance(SiteFinder::class);
+
+        try {
+            $sites = [];
+            if ($this->pageUid > 0) {
+                $site = $siteFinder->getSiteByPageId($this->pageUid);
+                $sites = [$site];
+            }
+            if (empty($sites)) {
+                $sites = $siteFinder->getAllSites();
+            }
+            foreach ($sites as $site) {
+                foreach ($site->getAllLanguages() as $siteLanguage) {
+                    $languageId = $siteLanguage->getLanguageId();
+                    if (!isset($seenIds[$languageId])) {
+                        $seenIds[$languageId] = true;
+                        $allowedLanguages[] = [
+                            'uid' => $languageId,
+                            'title' => $siteLanguage->getTitle() ?: ($languageId === 0 ? 'Default' : ('Language ' . $languageId)),
+                        ];
+                    }
+                }
+            }
+        } catch (SiteNotFoundException $e) {
+            // No site configured, e.g. during installation
+        }
+
+        if (empty($allowedLanguages)) {
+            $allowedLanguages = [
+                ['uid' => 0, 'title' => 'Default'],
+            ];
+        }
+
+        // Sort by language id so Default (0) is first
+        usort($allowedLanguages, static fn(array $a, array $b): int => $a['uid'] <=> $b['uid']);
+
+        return $allowedLanguages;
     }
 
     // HELPERS
@@ -627,6 +678,7 @@ class TranslatorController extends \TYPO3\CMS\Extbase\Mvc\Controller\ActionContr
 
         $this->moduleTemplate->assign('currentPage', $currentPage);
         $this->moduleTemplate->assign('languages', $this->listOfPossibleLanguages);
+        $this->moduleTemplate->assign('allowedLanguages', $this->getAllowedSystemLanguages());
         $entry = $databaseEntriesService->getCompleteCleanRow('pages', (int) $currentPage);
         $sourceLanguageUid = $entry['sys_language_uid'] ?? 0;
         $this->moduleTemplate->assign('currentLanguageUid', $sourceLanguageUid);
@@ -643,6 +695,7 @@ class TranslatorController extends \TYPO3\CMS\Extbase\Mvc\Controller\ActionContr
         $this->indexMenu();
 
         $this->moduleTemplate->assign('languages', $this->listOfPossibleLanguages);
+        $this->moduleTemplate->assign('allowedLanguages', $this->getAllowedSystemLanguages());
 
         $tables = [];
         foreach ($GLOBALS['TCA'] as $tableName => $data) {
@@ -682,7 +735,7 @@ class TranslatorController extends \TYPO3\CMS\Extbase\Mvc\Controller\ActionContr
         $saveToZip = true;
 
         $defaultLanguage = 1;
-        $sourceLangauge = 0;
+        $sourceLanguageUid = (int)($this->request->getArgument('sourceLanguageUid') ?? 0);
         $targetLanguage = 'de';
         //set to true, because it's the default value in $databaseEntriesService->exportDatabaseRowToXlf()
         $enableTranslatedData = true;
@@ -714,7 +767,7 @@ class TranslatorController extends \TYPO3\CMS\Extbase\Mvc\Controller\ActionContr
         $output = '';
         foreach ($storages as $storage) {
             foreach($tables as $tablename) {
-                $contentRows = $databaseEntriesService->getAllCompleteteRowsForPid($tablename, (int) $storage, $sourceLangauge,false);
+                $contentRows = $databaseEntriesService->getAllCompleteteRowsForPid($tablename, (int) $storage, $sourceLanguageUid, false);
                 if(empty($contentRows)) {
                     $output .= ' No entries in '.$tablename.' for pid '.$storage;
                 } else {
@@ -722,14 +775,21 @@ class TranslatorController extends \TYPO3\CMS\Extbase\Mvc\Controller\ActionContr
                         if ($saveToZip) {
                             $output = '';
                         }
-                        $cleanRow = $databaseEntriesService->getExportFields($tablename, $contentRow);
-                        $output .= $databaseEntriesService->exportDatabaseRowToXlf($contentRowUid, $cleanRow, $targetLanguage, $tablename, $enableTranslatedData, $source);
+                        $defaultUid = (int)$contentRowUid;
+                        $contentRowForKeys = $contentRow;
+                        if ((int)($contentRow['sys_language_uid'] ?? 0) !== 0 && !empty($contentRow['l10n_parent'] ?? null)) {
+                            $defaultUid = (int)$contentRow['l10n_parent'];
+                            $contentRowForKeys['uid'] = $defaultUid;
+                        }
+                        $cleanRow = $databaseEntriesService->getExportFields($tablename, $contentRowForKeys);
+                        $output .= $databaseEntriesService->exportDatabaseRowToXlf($defaultUid, $cleanRow, $targetLanguage, $tablename, $enableTranslatedData, $source);
 
                         if ($saveToZip) {
+                            $zipFilename = "$tablename-{$contentRow['pid']}-{$defaultUid}.xlf";
                             if (version_compare(PHP_VERSION, '8.0.0') >= 0) {
-                                $zip->addFromString("$tablename-{$contentRow['pid']}-{$contentRow['uid']}.xlf", $output, \ZipArchive::FL_OVERWRITE);
+                                $zip->addFromString($zipFilename, $output, \ZipArchive::FL_OVERWRITE);
                             } else {
-                                $zip->addFromString("$tablename-{$contentRow['pid']}-{$contentRow['uid']}.xlf", $output);
+                                $zip->addFromString($zipFilename, $output);
                             }
                         }
                     }
@@ -775,6 +835,7 @@ class TranslatorController extends \TYPO3\CMS\Extbase\Mvc\Controller\ActionContr
     public function databaseImportIndexAction()
     {
         $this->indexMenu();
+        $this->moduleTemplate->assign('allowedLanguages', $this->getAllowedSystemLanguages());
 
         return $this->moduleTemplate->renderResponse('Be/Translator/DatabaseImportIndex');
     }
@@ -919,6 +980,7 @@ class TranslatorController extends \TYPO3\CMS\Extbase\Mvc\Controller\ActionContr
         $this->moduleTemplate->assign('label', $label);
         $this->moduleTemplate->assign('fields', $databaseEntriesService->getExportFields($tablename, $row));
         $this->moduleTemplate->assign('languages', $this->listOfPossibleLanguages);
+        $this->moduleTemplate->assign('allowedLanguages', $this->getAllowedSystemLanguages());
         $this->moduleTemplate->assign('rowType', \Hyperdigital\HdTranslator\Services\DatabaseEntriesService::$rowType);
         $this->moduleTemplate->assign('rowTypeCouldBe', \Hyperdigital\HdTranslator\Services\DatabaseEntriesService::$rowTypeCouldBe);
 
@@ -933,11 +995,18 @@ class TranslatorController extends \TYPO3\CMS\Extbase\Mvc\Controller\ActionContr
     public function exportTableRowExportAction(string $tablename, int $rowUid)
     {
         $databaseEntriesService = GeneralUtility::makeInstance(\Hyperdigital\HdTranslator\Services\DatabaseEntriesService::class);
-        $row = $databaseEntriesService->getCompleteRow($tablename, $rowUid);
+        $sourceLanguageUid = (int)($this->request->getArgument('sourceLanguageUid') ?? 0);
+        $row = $databaseEntriesService->getCompleteRow($tablename, $rowUid, $sourceLanguageUid);
         $label = $databaseEntriesService->getFilenameFromLabel($tablename, $row);
 
-        $cleanRow = $databaseEntriesService->getExportFields($tablename, $row);
-        $output = $databaseEntriesService->exportDatabaseRowToXlf($rowUid, $cleanRow, $this->request->getArgument('language'), $tablename, true, $this->request->getArgument('source'));
+        $defaultUid = (int)($row['uid']);
+        $rowForKeys = $row;
+        if ((int)($row['sys_language_uid'] ?? 0) !== 0 && !empty($row['l10n_parent'] ?? null)) {
+            $defaultUid = (int)$row['l10n_parent'];
+            $rowForKeys['uid'] = $defaultUid;
+        }
+        $cleanRow = $databaseEntriesService->getExportFields($tablename, $rowForKeys);
+        $output = $databaseEntriesService->exportDatabaseRowToXlf($defaultUid, $cleanRow, $this->request->getArgument('language'), $tablename, true, $this->request->getArgument('source'));
         header('Content-type: text/xml');
         header('Content-Disposition: attachment; filename="'.$label.'.xlf"');
         echo $output;
@@ -1085,21 +1154,7 @@ class TranslatorController extends \TYPO3\CMS\Extbase\Mvc\Controller\ActionContr
             }
         }
 
-        $allowedLanguages = [];
-        $allowedLanguages[] = [
-            'uid' => 0,
-            'title' => 'Default'
-        ];
-
-        $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)->getConnectionForTable('sys_language')->createQueryBuilder();
-        $queryBuilder->getRestrictions()->removeAll()->add(GeneralUtility::makeInstance(DeletedRestriction::class));
-        $result = $queryBuilder->select('*')->from('sys_language')->execute();
-        while ($row = $result->fetch()) {
-            $allowedLanguages[] = $row;
-        }
-
-
-        $this->moduleTemplate->assign('allowedLanguages', $allowedLanguages);
+        $this->moduleTemplate->assign('allowedLanguages', $this->getAllowedSystemLanguages());
         $this->moduleTemplate->assign('tables', $fields);
 
         $this->moduleTemplate->setContent($this->moduleTemplate->render());

--- a/Classes/Services/DatabaseEntriesService.php
+++ b/Classes/Services/DatabaseEntriesService.php
@@ -324,7 +324,7 @@ class DatabaseEntriesService
             $row = $result->fetchAssociative();
         }
 
-        //setup default lanugage uid
+        //setup default language uid
         if (!empty($langaugeField) && isset($row[$langaugeField]) && $row[$langaugeField] == 0) {
             $parentUidField = 'uid';
         }
@@ -427,9 +427,19 @@ class DatabaseEntriesService
         }
         $result = $temp->executeQuery();
 
-        while($row = $result->fetchAssociative()) {
+        while ($row = $result->fetchAssociative()) {
             if ($clean) {
-                $return[$row['uid']] = $this->getExportFields($tablename, $row);
+                // Use default-language UID for export keys so import can map by default UID
+                $defaultUid = (int)$row['uid'];
+                if (!empty($GLOBALS['TCA'][$tablename]['ctrl']['transOrigPointerField'])
+                    && isset($row[$parentUidField])
+                    && (int)($row[$langaugeField] ?? 0) !== 0
+                ) {
+                    $defaultUid = (int)$row[$parentUidField];
+                }
+                $rowForKeys = $row;
+                $rowForKeys['uid'] = $defaultUid;
+                $return[$defaultUid] = $this->getExportFields($tablename, $rowForKeys);
             } else {
                 $return[$row['uid']] = $row;
             }
@@ -984,12 +994,14 @@ class DatabaseEntriesService
     {
         $row = $this->getCompleteRow('pages', $uid, $sourceLanguage);
 
-        $realUid = $uid;// PID of other contents
-        if ($row['sys_language_uid'] != 0 ) {
-            $realUid = (int)$row['l10n_parent']; // The page is just translation;
+        $realUid = $uid;// PID of other contents (default-language page UID)
+        if (($row['sys_language_uid'] ?? 0) != 0) {
+            $realUid = (int)$row['l10n_parent']; // The page is a translation; use default-language UID for export keys
         }
         if ($clean) {
-            $row = $this->getExportFields('pages', $row);
+            $pageRowForKeys = $row;
+            $pageRowForKeys['uid'] = $realUid;
+            $row = $this->getExportFields('pages', $pageRowForKeys);
             $output = $this->prepareDataFromRow($realUid, $row, $targetLanguage, 'pages');
         }
 

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -129,17 +129,17 @@
             <trans-unit id="deepl.index.noAvailableLanguages.description">
                 <source>First to enable AI languages you need to synchronize them.</source>
             </trans-unit>
-            <trans-unit id="deepl.index.availableLanugages">
-                <source>Available langauges</source>
+            <trans-unit id="deepl.index.availableLanguages">
+                <source>Available languages</source>
             </trans-unit>
-            <trans-unit id="deepl.index.table.langauges">
+            <trans-unit id="deepl.index.table.languages">
                 <source>Languages</source>
             </trans-unit>
             <trans-unit id="deepl.index.table.translation_count">
                 <source>Amount of translations</source>
             </trans-unit>
             <trans-unit id="deepl.language.headline">
-                <source>Deepl AI translations for %s langauge</source>
+                <source>Deepl AI translations for %s language</source>
             </trans-unit>
             <trans-unit id="deepl.language.nothingTranslated">
                 <source>There is nothing translated in %s language yet.</source>

--- a/Resources/Private/Templates/Be/Translator/Database.html
+++ b/Resources/Private/Templates/Be/Translator/Database.html
@@ -13,9 +13,19 @@
 		<f:form action="databaseExport">
 			<div class="row row-cols-auto align-items-end g-3">
 				<div class="col">
-					<label for="source" class="form-label">Source language</label>
+					<label for="sourceLanguageUid" class="form-label">Source TYPO3 Language</label>
 					<div class="input-group">
-						<f:form.textfield name="source-language" class="form-control" id="source" value="en" />
+						<f:form.select name="sourceLanguageUid" id="sourceLanguageUid" class="form-select" value="0">
+							<f:for each="{allowedLanguages}" as="lang">
+								<f:form.select.option value="{lang.uid}">{lang.title}</f:form.select.option>
+							</f:for>
+						</f:form.select>
+					</div>
+				</div>
+				<div class="col">
+					<label for="source-language" class="form-label">Source language (XLF code)</label>
+					<div class="input-group">
+						<f:form.textfield name="source-language" class="form-control" id="source-language" value="en" />
 						<f:form.select name="source-temp" class="form-select hd-form-select btn-light" id="source-temp">
 							<f:form.select.option value=""></f:form.select.option>
 							<f:for each="{languages}" as="language" key="key">
@@ -25,7 +35,7 @@
 					</div>
 				</div>
 				<div class="col">
-					<label for="target" class="form-label">Target language</label>
+					<label for="target" class="form-label">Target language (XLF code)</label>
 					<div class="input-group">
 						<f:form.textfield name="language" class="form-control" id="target" value="en" />
 						<f:form.select name="target-temp" class="form-select hd-form-select btn-light" id="target-temp">

--- a/Resources/Private/Templates/Be/Translator/DatabaseImportIndex.html
+++ b/Resources/Private/Templates/Be/Translator/DatabaseImportIndex.html
@@ -27,9 +27,13 @@
 						</div>
 					</div>
 					<div class="col">
-						<label for="language-uid" class="form-label">Lanugage UID</label>
+						<label for="language-uid" class="form-label">Target TYPO3 Language</label>
 						<div class="input-group">
-							<f:form.textfield name="targetLanguageUid" class="form-control" id="language-uid" value="1" />
+							<f:form.select name="targetLanguageUid" id="language-uid" class="form-select" value="1">
+								<f:for each="{allowedLanguages}" as="lang">
+									<f:form.select.option value="{lang.uid}">{lang.title}</f:form.select.option>
+								</f:for>
+							</f:form.select>
 						</div>
 					</div>
 					<div class="col">

--- a/Resources/Private/Templates/Be/Translator/DeeplTranslationsList.html
+++ b/Resources/Private/Templates/Be/Translator/DeeplTranslationsList.html
@@ -28,12 +28,12 @@
                         <f:link.action action="deeplOriginalSources" class="btn btn-default">Search by original sources</f:link.action>
                     </p>
 
-                    <h2><f:translate key="LLL:EXT:hd_translator/Resources/Private/Language/locallang.xlf:deepl.index.availableLanugages" /></h2>
+                    <h2><f:translate key="LLL:EXT:hd_translator/Resources/Private/Language/locallang.xlf:deepl.index.availableLanguages" /></h2>
 
                     <table class="table table-hover">
                         <thead>
                         <tr>
-                            <th><f:translate key="LLL:EXT:hd_translator/Resources/Private/Language/locallang.xlf:deepl.index.table.langauges" /></th>
+                            <th><f:translate key="LLL:EXT:hd_translator/Resources/Private/Language/locallang.xlf:deepl.index.table.languages" /></th>
                             <th><f:translate key="LLL:EXT:hd_translator/Resources/Private/Language/locallang.xlf:deepl.index.table.translation_count" /></th>
                             <th class="col-control"></th>
                         </tr>

--- a/Resources/Private/Templates/Be/Translator/ExportTableRowIndex.html
+++ b/Resources/Private/Templates/Be/Translator/ExportTableRowIndex.html
@@ -48,7 +48,17 @@
                     <f:form action="exportTableRowExport" arguments="{tablename: tablename, rowUid: rowUid}">
 											<div class="row row-cols-auto align-items-end g-3">
 												<div class="col">
-													<label for="source" class="form-label">Source language</label>
+													<label for="sourceLanguageUid" class="form-label">Source TYPO3 Language</label>
+													<div class="input-group">
+														<f:form.select name="sourceLanguageUid" id="sourceLanguageUid" class="form-select" value="0">
+															<f:for each="{allowedLanguages}" as="lang">
+																<f:form.select.option value="{lang.uid}">{lang.title}</f:form.select.option>
+															</f:for>
+														</f:form.select>
+													</div>
+												</div>
+												<div class="col">
+													<label for="source" class="form-label">Source language (XLF code)</label>
 													<div class="input-group">
 														<f:form.textfield name="source" class="form-control" id="source" value="en" />
 														<f:form.select name="source-temp" class="form-select hd-form-select btn-light" id="source-temp">
@@ -60,7 +70,7 @@
 													</div>
 												</div>
 												<div class="col">
-													<label for="target" class="form-label">Target language</label>
+													<label for="target" class="form-label">Target language (XLF code)</label>
 													<div class="input-group">
 														<f:form.textfield name="language" class="form-control" id="target" value="en" />
 														<f:form.select name="target-temp" class="form-select hd-form-select btn-light" id="target-temp">

--- a/Resources/Private/Templates/Be/Translator/PageContentExport.html
+++ b/Resources/Private/Templates/Be/Translator/PageContentExport.html
@@ -16,9 +16,13 @@
         <f:form action="pageContentExportProccess">
 					<div class="row row-cols-auto align-items-end g-3">
 						<div class="col">
-							<label for="source" class="form-label">Source from language UID</label>
+							<label for="source" class="form-label">Source TYPO3 Language</label>
 							<div class="input-group">
-								<f:form.textfield name="source" class="form-control" id="source" value="{currentLanguageUid}" />
+								<f:form.select name="source" id="source" class="form-select" value="{currentLanguageUid}">
+									<f:for each="{allowedLanguages}" as="lang">
+										<f:form.select.option value="{lang.uid}">{lang.title}</f:form.select.option>
+									</f:for>
+								</f:form.select>
 							</div>
 						</div>
 						<div class="col">
@@ -34,7 +38,7 @@
 							</div>
 						</div>
 						<div class="col">
-							<label for="target" class="form-label">Target language</label>
+							<label for="target" class="form-label">Target language (XLF code)</label>
 							<div class="input-group">
 								<f:form.textfield name="language" class="form-control" id="target" value="en" />
 								<f:form.select name="target-temp" class="form-select hd-form-select btn-light" id="target-temp">

--- a/Resources/Public/JavaScript/Database.js
+++ b/Resources/Public/JavaScript/Database.js
@@ -1,5 +1,5 @@
 const sourceTemp = document.getElementById('source-temp');
-const source = document.getElementById('source');
+const source = document.getElementById('source-language');
 const targetTemp = document.getElementById('target-temp');
 const target = document.getElementById('target');
 


### PR DESCRIPTION
When doing a database export, the editor can now use a dropdown to select the source language. The target language can also be now selected via a dropdown (instead of an input field).

- Introduced `getAllowedSystemLanguages` method to fetch languages.
- Updated templates to use dropdowns for language selection.
- Refactored source/UID handling for default and translation pages.
- Fixed language-related typos in templates and language files.